### PR TITLE
Adds unassign/assign commands on CLI and Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Usage: pyaxm-cli COMMAND [ARGS]
 
 `mdm-server-assigned` -> Get the server assignment for a device.
 
+`assign-device` -> Assign a device to an MDM server.
+
+`unassign-device` -> Unassign a device from an MDM server.
+
 The data returned is on CSV format so you can store it as a CSV if needed
 
 # Client:
@@ -58,10 +62,16 @@ print(mdm_server)
 
 device_assigned_server = axm_client.list_devices_in_mdm_server(device_id='SERIAL_NUMBER')
 print(device_assigned_server)
+
+assignment_result = axm_client.assign_unassign_device_to_mdm_server(
+    device_id='SERIAL_NUMBER',
+    server_id="MDM_SERVER_ID",
+    action="ASSIGN_DEVICES"|"UNASSIGN_DEVICES"
+)
 ```
 
 ## Issues:
 * need to add tests
-* not all api functionability is there
+* unassign, assign devices need to be able to pass more than 1 device
 
 This is still a work in progress

--- a/pyaxm/cli.py
+++ b/pyaxm/cli.py
@@ -46,7 +46,14 @@ def mdm_server_assigned(device_id: str):
 @app.command()
 def assign_device(device_id: str, server_id: str):
     """Assign a device to an MDM server."""
-    client.assign_unassign_device_to_mdm_server(device_id, server_id, 'ASSIGN_DEVICES')
+    df = pd.DataFrame([client.assign_unassign_device_to_mdm_server(device_id, server_id, 'ASSIGN_DEVICES')])
+    df.to_csv(sys.stdout, index=False)
+
+@app.command()
+def unassign_device(device_id: str, server_id: str):
+    """Unassign a device from an MDM server."""
+    df = pd.DataFrame([client.assign_unassign_device_to_mdm_server(device_id, server_id, 'UNASSIGN_DEVICES')])
+    df.to_csv(sys.stdout, index=False)
 
 if __name__ == "__main__":
     app()

--- a/pyaxm/cli.py
+++ b/pyaxm/cli.py
@@ -43,5 +43,10 @@ def mdm_server_assigned(device_id: str):
     except DeviceError as e:
         typer.echo(e)
 
+@app.command()
+def assign_device(device_id: str, server_id: str):
+    """Assign a device to an MDM server."""
+    client.assign_unassign_device_to_mdm_server(device_id, server_id, 'ASSIGN_DEVICES')
+
 if __name__ == "__main__":
     app()

--- a/pyaxm/client.py
+++ b/pyaxm/client.py
@@ -174,7 +174,10 @@ class Client:
 
         # use the ID to check the status until it is complete
         activity_response = self.abm.get_device_activity(unassign_response.data.id, self.access_token.value)
-        while 'COMPLETED' not in activity_response.data.attributes.status:
-            time.sleep(5)
+        retry = 0
+        while 'COMPLETED' not in activity_response.data.attributes.status and retry < 5:
+            time.sleep(2 ** retry)
+            retry += 1
             activity_response = self.abm.get_device_activity(unassign_response.data.id, self.access_token.value)
-        print(activity_response)
+
+        return activity_response.data.attributes.model_dump()

--- a/pyaxm/client.py
+++ b/pyaxm/client.py
@@ -156,3 +156,25 @@ class Client:
             'id'
         }
         return response.data.model_dump(include=include_keys)
+
+    @ensure_valid_token
+    def assign_unassign_device_to_mdm_server(
+        self, device_id: str, server_id: str, action: str
+    ) -> None:
+        """
+        Assign or unassign a device to/from an MDM server.
+
+        :param device_id: The ID of the device.
+        :param server_id: The ID of the MDM server.
+        :param action: 'assign' or 'unassign'.
+        """
+        unassign_response = self.abm.assign_unassign_device_to_mdm_server(
+            device_id, server_id, action, self.access_token.value
+        )
+
+        # use the ID to check the status until it is complete
+        activity_response = self.abm.get_device_activity(unassign_response.data.id, self.access_token.value)
+        while 'COMPLETED' not in activity_response.data.attributes.status:
+            time.sleep(5)
+            activity_response = self.abm.get_device_activity(unassign_response.data.id, self.access_token.value)
+        print(activity_response)

--- a/pyaxm/models.py
+++ b/pyaxm/models.py
@@ -3,8 +3,8 @@ from typing import List, Optional
 from enum import Enum
 
 class OrgDeviceActivityType(Enum):
-    ASSIGN_DEVICE = "ASSIGN_DEVICE"
-    UNASSIGN_DEVICE = "UNASSIGN_DEVICE"
+    ASSIGN_DEVICES = "ASSIGN_DEVICES"
+    UNASSIGN_DEVICES = "UNASSIGN_DEVICES"
 
 class DocumentLinks(BaseModel):
     self: str # uri-reference to the current document
@@ -86,6 +86,7 @@ class OrgDeviceActivityCreateRequest(BaseModel):
     class Data(BaseModel):
         class Attributes(BaseModel):
             activityType: OrgDeviceActivityType
+            model_config = ConfigDict(use_enum_values=True)
         
         class Relationships(BaseModel):
             class Devices(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyaxm"
-version = "2025.06.20"
+version = "2025.06.22"
 description = "Query Apple Business Manager using Python"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
This pull request introduces functionality to assign and unassign devices to/from MDM servers, along with supporting changes to the CLI, API client, and models. It also includes minor updates to documentation and versioning.

### New functionality for device assignment:

* [`pyaxm/abm_requests.py`](diffhunk://#diff-65b4492b87126d8fb47b4d04477ad4d7b0b947e62da5d9d3aa0be54d24d36381R161-R229): Added methods `assign_unassign_device_to_mdm_server` and `get_device_activity` to handle device assignment/unassignment and track activity status. These methods include exponential backoff for retries and validate request/response data using models.
* [`pyaxm/client.py`](diffhunk://#diff-b95fc152ab2f0437b5b1ab85c74ea71a543a10c5f4813eb486677ea326ff5c6fR159-R183): Added `assign_unassign_device_to_mdm_server` method to integrate with the ABM API and ensure the activity is completed before returning the response.

### CLI enhancements:

* [`pyaxm/cli.py`](diffhunk://#diff-1077f9787b4d0373be82aa876fd15ed9a1f57459b4cdd8ee5671f1bd98e4daf3R46-R57): Added new commands `assign_device` and `unassign_device` to allow users to assign/unassign devices via the CLI, with results output in CSV format.

### Model updates:

* [`pyaxm/models.py`](diffhunk://#diff-f7223a8337a49818179a0db3a810aa946b9ca925d4ea85eedfd90c7ef39c8820L6-R7): Updated `OrgDeviceActivityType` enum to support pluralized activity types (`ASSIGN_DEVICES` and `UNASSIGN_DEVICES`). Added `model_config` to `OrgDeviceActivityCreateRequest` for enum value usage in validation. [[1]](diffhunk://#diff-f7223a8337a49818179a0db3a810aa946b9ca925d4ea85eedfd90c7ef39c8820L6-R7) [[2]](diffhunk://#diff-f7223a8337a49818179a0db3a810aa946b9ca925d4ea85eedfd90c7ef39c8820R89)

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R41): Updated the usage section to include new commands (`assign-device` and `unassign-device`) and provided an example for assigning/unassigning devices. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R41) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R65-R75)

### Version update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Incremented the project version from `2025.06.20` to `2025.06.22`.