### PR TITLE
Updates models and adds `wifiMacAddress` and `bluetoothMacAddress` to `OrgDevice.Attributes`

### DIFF
--- a/pyaxm/models.py
+++ b/pyaxm/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict, AnyHttpUrl
+from pydantic import BaseModel, ConfigDict, AnyHttpUrl, AwareDatetime
 from typing import List, Optional
 from enum import Enum
 
@@ -31,14 +31,14 @@ class PagedDocumentLinks(BaseModel):
 # OrgDevice
 class OrgDevice(BaseModel):
     class Attributes(BaseModel):
-        addedToOrgDateTime: Optional[str] # ISO 8601 date-time
+        addedToOrgDateTime: Optional[AwareDatetime]
         color: Optional[str]
         deviceCapacity: Optional[str]
         deviceModel: Optional[str]
         eid: Optional[str]
         imei: Optional[List[str]]
         meid: Optional[List[str]]
-        orderDateTime: Optional[str] # ISO 8601 date-time
+        orderDateTime: Optional[AwareDatetime]
         orderNumber: Optional[str]
         partNumber: Optional[str]
         productFamily: Optional[str]
@@ -47,7 +47,7 @@ class OrgDevice(BaseModel):
         purchaseSourceId: Optional[str]
         serialNumber: Optional[str]
         status: Optional[str]
-        updatedDateTime: Optional[str] # ISO 8601 date-time
+        updatedDateTime: Optional[AwareDatetime]
     
     class Relationships(BaseModel):
         class AssignedServer(BaseModel):
@@ -71,10 +71,10 @@ class OrgDeviceAssignedServerLinkageResponse(BaseModel):
 
 class OrgDeviceActivity(BaseModel):
     class Attributes(BaseModel):
-        createdDateTime: Optional[str] # ISO 8601 date-time
+        createdDateTime: Optional[AwareDatetime]
         status: Optional[str]
         subStatus: Optional[str]
-        completedDateTime: Optional[str] # ISO 8601 date-time
+        completedDateTime: Optional[AwareDatetime]
         downloadUrl: Optional[str]
 
     attributes: Optional[Attributes]
@@ -121,10 +121,10 @@ class PagingInformation(BaseModel):
 
 class MdmServer(BaseModel):
     class Attributes(BaseModel):
-        createdDateTime: Optional[str] # ISO 8601 date-time
+        createdDateTime: Optional[AwareDatetime]
         serverName: Optional[str]
         serverType: Optional[str]
-        updatedDateTime: Optional[str] # ISO 8601 date-time
+        updatedDateTime: Optional[AwareDatetime]
     
     class Relationships(BaseModel):
         class Devices(BaseModel):

--- a/pyaxm/models.py
+++ b/pyaxm/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, ConfigDict, AnyHttpUrl, AwareDatetime
-from typing import List, Optional
+from typing import List, Optional, Literal
 from enum import Enum
 
 class OrgDeviceActivityType(Enum):
@@ -16,12 +16,12 @@ class JsonPointer(BaseModel):
     pointer: str
 
 class ResourceLinks(BaseModel):
-    self: Optional[AnyHttpUrl]
+    self: Optional[AnyHttpUrl] = None
 
 class RelationshipLinks(BaseModel):
-    include: Optional[str] = None # is this really a field? #### TODO: confirm
+    include: Optional[AnyHttpUrl] = None
     related: Optional[AnyHttpUrl] = None
-    self: Optional[AnyHttpUrl]
+    self: Optional[AnyHttpUrl] = None
 
 class PagedDocumentLinks(BaseModel):
     first: Optional[AnyHttpUrl] = None
@@ -31,23 +31,25 @@ class PagedDocumentLinks(BaseModel):
 # OrgDevice
 class OrgDevice(BaseModel):
     class Attributes(BaseModel):
-        addedToOrgDateTime: Optional[AwareDatetime]
-        color: Optional[str]
-        deviceCapacity: Optional[str]
-        deviceModel: Optional[str]
-        eid: Optional[str]
-        imei: Optional[List[str]]
-        meid: Optional[List[str]]
-        orderDateTime: Optional[AwareDatetime]
-        orderNumber: Optional[str]
-        partNumber: Optional[str]
-        productFamily: Optional[str]
-        productType: Optional[str]
-        purchaseSourceType: Optional[str]
-        purchaseSourceId: Optional[str]
-        serialNumber: Optional[str]
-        status: Optional[str]
-        updatedDateTime: Optional[AwareDatetime]
+        addedToOrgDateTime: Optional[AwareDatetime] = None
+        color: Optional[str] = None
+        deviceCapacity: Optional[str] = None
+        deviceModel: Optional[str] = None
+        eid: Optional[str] = None
+        imei: Optional[List[str]] = None
+        meid: Optional[List[str]] = None
+        wifiMacAddress: Optional[str] = None
+        bluetoothMacAddress: Optional[str] = None
+        orderDateTime: Optional[AwareDatetime] = None
+        orderNumber: Optional[str] = None
+        partNumber: Optional[str] = None
+        productFamily: Optional[str] = None
+        productType: Optional[str] = None
+        purchaseSourceType: Optional[str] = None
+        purchaseSourceId: Optional[str] = None
+        serialNumber: Optional[str] = None
+        status: Optional[str] = None
+        updatedDateTime: Optional[AwareDatetime] = None
     
     class Relationships(BaseModel):
         class AssignedServer(BaseModel):
@@ -59,28 +61,28 @@ class OrgDevice(BaseModel):
     id: str
     links: Optional[ResourceLinks]
     relationships: Optional[Relationships]
-    type: str
+    type: Literal['orgDevices']
 
 class OrgDeviceAssignedServerLinkageResponse(BaseModel):
     class Data(BaseModel):
         id: str
-        type: str
+        type: Literal['mdmServers']
 
     data: Data
     links: DocumentLinks
 
 class OrgDeviceActivity(BaseModel):
     class Attributes(BaseModel):
-        createdDateTime: Optional[AwareDatetime]
-        status: Optional[str]
-        subStatus: Optional[str]
-        completedDateTime: Optional[AwareDatetime]
-        downloadUrl: Optional[str]
+        createdDateTime: Optional[AwareDatetime] = None
+        status: Optional[str] = None
+        subStatus: Optional[str] = None
+        completedDateTime: Optional[AwareDatetime] = None
+        downloadUrl: Optional[str] = None
 
     attributes: Optional[Attributes]
     id: str
     links: Optional[ResourceLinks]
-    type: str
+    type: Literal['orgDeviceActivities']
 
 class OrgDeviceActivityCreateRequest(BaseModel):
     class Data(BaseModel):
@@ -92,14 +94,14 @@ class OrgDeviceActivityCreateRequest(BaseModel):
             class Devices(BaseModel):
                 class Data(BaseModel):
                     id: str
-                    type: str
+                    type: Literal['orgDevices']
                 
                 data: List[Data]
             
             class MdmServer(BaseModel):
                 class Data(BaseModel):
                     id: str
-                    type: str
+                    type: Literal['mdmServers']
 
                 data: Data
 
@@ -108,49 +110,40 @@ class OrgDeviceActivityCreateRequest(BaseModel):
 
         attributes: Attributes
         relationships: Relationships
-        type: str
+        type: Literal['orgDeviceActivities']
     data: Data
 
 class PagingInformation(BaseModel):
     class Paging(BaseModel):
         limit: int
-        nextCursor: Optional[str] = None # also weird not being passed
-        total: Optional[int] = None # also not being passed
+        nextCursor: Optional[str] = None
+        total: Optional[int] = None
 
     paging: Paging
 
 class MdmServer(BaseModel):
     class Attributes(BaseModel):
-        createdDateTime: Optional[AwareDatetime]
-        serverName: Optional[str]
-        serverType: Optional[str]
-        updatedDateTime: Optional[AwareDatetime]
+        createdDateTime: Optional[AwareDatetime] = None
+        serverName: Optional[str] = None
+        serverType: Optional[str] = None
+        updatedDateTime: Optional[AwareDatetime] = None
     
     class Relationships(BaseModel):
         class Devices(BaseModel):
             class Data(BaseModel):
                 id: str
-                type: str
+                type: Literal['orgDevices']
 
-            data: Optional[List[Data]] = None # weird also not being returned
+            data: Optional[List[Data]] = None
             links: Optional[RelationshipLinks]
-            meta: Optional[PagingInformation] = None # also weird
+            meta: Optional[PagingInformation] = None
 
         devices: Optional[Devices]
 
     attributes: Optional[Attributes]
     id: str
     relationships: Optional[Relationships]
-    type: str
-
-class MdmServerLinkageResponse(BaseModel):
-    class Data(BaseModel):
-        id: str
-        type: str
-
-    data: Data
-    links: PagedDocumentLinks
-    meta: Optional[PagingInformation]
+    type: Literal['mdmServers']
 
 class OrgDeviceActivityResponse(BaseModel):
     data: OrgDeviceActivity
@@ -158,7 +151,7 @@ class OrgDeviceActivityResponse(BaseModel):
 
 class MdmServersResponse(BaseModel):
     data: List[MdmServer]
-    included: Optional[List[OrgDevice]] = None # weird not being returned
+    included: Optional[List[OrgDevice]] = None
     links: PagedDocumentLinks
     meta: Optional[PagingInformation]
 
@@ -179,13 +172,13 @@ class OrgDeviceResponse(BaseModel):
 class ErrorLinks(BaseModel):
     class Associated(BaseModel):
         class Meta(BaseModel):
-            source: Optional[str]
+            source: Optional[str] = None
         
-        href: Optional[AnyHttpUrl]
-        meta: Optional[Meta]
+        href: Optional[AnyHttpUrl] = None
+        meta: Optional[Meta] = None
     
-    about: Optional[AnyHttpUrl]
-    associated: Optional[AnyHttpUrl|Associated]
+    about: Optional[AnyHttpUrl] = None
+    associated: Optional[AnyHttpUrl|Associated] = None
 
 class ErrorResponse(BaseModel):
     class Errors(BaseModel):
@@ -195,7 +188,7 @@ class ErrorResponse(BaseModel):
 
         code: str
         detail: str
-        id: Optional[str]
+        id: Optional[str] = None
         source: Optional[JsonPointer|Parameter] = None
         status: str
         title: str
@@ -207,7 +200,7 @@ class ErrorResponse(BaseModel):
 class MdmServerDevicesLinkagesResponse(BaseModel):
     class Data(BaseModel):
         id: str
-        type: str
+        type: Literal['orgDevices']
 
     data: List[Data]
     links: PagedDocumentLinks

--- a/pyaxm/models.py
+++ b/pyaxm/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, AnyHttpUrl
 from typing import List, Optional
 from enum import Enum
 
@@ -7,7 +7,7 @@ class OrgDeviceActivityType(Enum):
     UNASSIGN_DEVICES = "UNASSIGN_DEVICES"
 
 class DocumentLinks(BaseModel):
-    self: str # uri-reference to the current document
+    self: AnyHttpUrl
 
 class Parameter(BaseModel):
     parameter: str
@@ -16,17 +16,17 @@ class JsonPointer(BaseModel):
     pointer: str
 
 class ResourceLinks(BaseModel):
-    self: Optional[str] # uri-reference. Link to the resource
+    self: Optional[AnyHttpUrl]
 
 class RelationshipLinks(BaseModel):
     include: Optional[str] = None # is this really a field? #### TODO: confirm
-    related: Optional[str] = None # uri-reference
-    self: Optional[str] # uri-reference
+    related: Optional[AnyHttpUrl] = None
+    self: Optional[AnyHttpUrl]
 
 class PagedDocumentLinks(BaseModel):
-    first: Optional[str] = None # uri-reference
-    next: Optional[str] = None # uri-reference
-    self: str # uri-reference
+    first: Optional[AnyHttpUrl] = None
+    next: Optional[AnyHttpUrl] = None
+    self: AnyHttpUrl
 
 # OrgDevice
 class OrgDevice(BaseModel):
@@ -181,11 +181,11 @@ class ErrorLinks(BaseModel):
         class Meta(BaseModel):
             source: Optional[str]
         
-        href: Optional[str] # uri-reference
+        href: Optional[AnyHttpUrl]
         meta: Optional[Meta]
     
-    about: Optional[str] # uri-reference
-    associated: Optional[str|Associated] # uri-reference or Associated object
+    about: Optional[AnyHttpUrl]
+    associated: Optional[AnyHttpUrl|Associated]
 
 class ErrorResponse(BaseModel):
     class Errors(BaseModel):

--- a/pyaxm/models.py
+++ b/pyaxm/models.py
@@ -53,14 +53,14 @@ class OrgDevice(BaseModel):
     
     class Relationships(BaseModel):
         class AssignedServer(BaseModel):
-            links: Optional[RelationshipLinks]
+            links: Optional[RelationshipLinks] = None
 
-        assignedServer: Optional[AssignedServer]
+        assignedServer: Optional[AssignedServer] = None
 
-    attributes: Optional[Attributes]
+    attributes: Optional[Attributes] = None
     id: str
-    links: Optional[ResourceLinks]
-    relationships: Optional[Relationships]
+    links: Optional[ResourceLinks] = None
+    relationships: Optional[Relationships] = None
     type: Literal['orgDevices']
 
 class OrgDeviceAssignedServerLinkageResponse(BaseModel):
@@ -79,9 +79,9 @@ class OrgDeviceActivity(BaseModel):
         completedDateTime: Optional[AwareDatetime] = None
         downloadUrl: Optional[str] = None
 
-    attributes: Optional[Attributes]
+    attributes: Optional[Attributes] = None
     id: str
-    links: Optional[ResourceLinks]
+    links: Optional[ResourceLinks] = None
     type: Literal['orgDeviceActivities']
 
 class OrgDeviceActivityCreateRequest(BaseModel):
@@ -135,14 +135,14 @@ class MdmServer(BaseModel):
                 type: Literal['orgDevices']
 
             data: Optional[List[Data]] = None
-            links: Optional[RelationshipLinks]
+            links: Optional[RelationshipLinks] = None
             meta: Optional[PagingInformation] = None
 
-        devices: Optional[Devices]
+        devices: Optional[Devices] = None
 
-    attributes: Optional[Attributes]
+    attributes: Optional[Attributes] = None
     id: str
-    relationships: Optional[Relationships]
+    relationships: Optional[Relationships] = None
     type: Literal['mdmServers']
 
 class OrgDeviceActivityResponse(BaseModel):
@@ -153,17 +153,17 @@ class MdmServersResponse(BaseModel):
     data: List[MdmServer]
     included: Optional[List[OrgDevice]] = None
     links: PagedDocumentLinks
-    meta: Optional[PagingInformation]
+    meta: Optional[PagingInformation] = None
 
 class MdmServerResponse(BaseModel):
     data: MdmServer
-    included: Optional[List[OrgDevice]]
+    included: Optional[List[OrgDevice]] = None
     links: DocumentLinks
 
 class OrgDevicesResponse(BaseModel):
     data: List[OrgDevice]
     links: PagedDocumentLinks
-    meta: Optional[PagingInformation]
+    meta: Optional[PagingInformation] = None
 
 class OrgDeviceResponse(BaseModel):
     data: OrgDevice
@@ -195,7 +195,7 @@ class ErrorResponse(BaseModel):
         links: Optional[ErrorLinks] = None
         meta: Optional[Meta] = None
     
-    errors: Optional[List[Errors]]
+    errors: Optional[List[Errors]] = None
 
 class MdmServerDevicesLinkagesResponse(BaseModel):
     class Data(BaseModel):
@@ -204,4 +204,4 @@ class MdmServerDevicesLinkagesResponse(BaseModel):
 
     data: List[Data]
     links: PagedDocumentLinks
-    meta: Optional[PagingInformation]
+    meta: Optional[PagingInformation] = None


### PR DESCRIPTION
This pull request updates the `pyaxm/models.py` file to enhance type safety and improve data validation by replacing generic types with more specific ones, such as `AnyHttpUrl` and `Literal`. It also adds default values for optional fields and refines several model classes for consistency and clarity.

### Type Safety and Validation Improvements:
* Replaced `str` with `AnyHttpUrl` for fields representing URLs across multiple classes, including `DocumentLinks`, `ResourceLinks`, `RelationshipLinks`, `PagedDocumentLinks`, and `ErrorLinks`. This ensures proper validation of URL formats. [[1]](diffhunk://#diff-f7223a8337a49818179a0db3a810aa946b9ca925d4ea85eedfd90c7ef39c8820L1-R10) [[2]](diffhunk://#diff-f7223a8337a49818179a0db3a810aa946b9ca925d4ea85eedfd90c7ef39c8820L19-R85) [[3]](diffhunk://#diff-f7223a8337a49818179a0db3a810aa946b9ca925d4ea85eedfd90c7ef39c8820L182-R181)
* Introduced `Literal` types for `type` fields to enforce specific string values, such as `'orgDevices'` and `'mdmServers'`, across various models like `OrgDevice`, `OrgDeviceActivity`, and `MdmServer`. [[1]](diffhunk://#diff-f7223a8337a49818179a0db3a810aa946b9ca925d4ea85eedfd90c7ef39c8820L95-R104) [[2]](diffhunk://#diff-f7223a8337a49818179a0db3a810aa946b9ca925d4ea85eedfd90c7ef39c8820L111-R166)

### Default Values for Optional Fields:
* Added `None` as the default value for optional fields to improve clarity and reduce ambiguity in model definitions. This change affects attributes in classes such as `OrgDevice`, `MdmServer`, and `ErrorLinks`. [[1]](diffhunk://#diff-f7223a8337a49818179a0db3a810aa946b9ca925d4ea85eedfd90c7ef39c8820L19-R85) [[2]](diffhunk://#diff-f7223a8337a49818179a0db3a810aa946b9ca925d4ea85eedfd90c7ef39c8820L198-R207)

### Enhanced Date-Time Handling:
* Replaced `str` with `AwareDatetime` for fields representing ISO 8601 date-time values, improving type safety and ensuring proper handling of time zones. This change affects models like `OrgDevice`, `OrgDeviceActivity`, and `MdmServer`. [[1]](diffhunk://#diff-f7223a8337a49818179a0db3a810aa946b9ca925d4ea85eedfd90c7ef39c8820L19-R85) [[2]](diffhunk://#diff-f7223a8337a49818179a0db3a810aa946b9ca925d4ea85eedfd90c7ef39c8820L111-R166)

### Consistency in Model Definitions:
* Refined model attributes by ensuring uniformity in optional fields and removing unnecessary comments. Added new fields like `wifiMacAddress` and `bluetoothMacAddress` to `OrgDevice.Attributes` for extended functionality.

These updates collectively enhance the robustness and maintainability of the codebase by leveraging Pydantic's advanced features for data validation and type enforcement.