### PR TITLE
adds download util and fixes assign/unassign devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,11 @@ device_assigned_server = axm_client.list_devices_in_mdm_server(device_id='SERIAL
 print(device_assigned_server)
 
 assignment_result = axm_client.assign_unassign_device_to_mdm_server(
-    device_id='SERIAL_NUMBER',
+    device_ids=['SERIAL_NUMBER', "ANOTHER_SERIAL_NUMBER"],
     server_id="MDM_SERVER_ID",
     action="ASSIGN_DEVICES"|"UNASSIGN_DEVICES"
 )
+print(assignment_result)
 
 apple_care_coverage = axm_client.get_apple_care_coverage(device_id='SERIAL_NUMBER')
 print(apple_care_coverage)
@@ -90,6 +91,5 @@ print(apple_care_coverage)
 
 ## Issues:
 * need to add tests
-* unassign, assign devices need to be able to pass more than 1 device
 
 This is still a work in progress

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -130,12 +130,12 @@ Assign one or more devices to an MDM server.
 **Usage**:
 
 ```console
-$ pyaxm-cli assign-device [OPTIONS] DEVICE_ID... SERVER_ID
+$ pyaxm-cli assign-device [OPTIONS] DEVICE_IDS... SERVER_ID
 ```
 
 **Arguments**:
 
-* `DEVICE_ID...`: [required]
+* `DEVICE_IDS...`: [required]
 * `SERVER_ID`: [required]
 
 **Options**:
@@ -149,12 +149,12 @@ Unassign one or more devices from an MDM server.
 **Usage**:
 
 ```console
-$ pyaxm-cli unassign-device [OPTIONS] DEVICE_ID... SERVER_ID
+$ pyaxm-cli unassign-device [OPTIONS] DEVICE_IDS... SERVER_ID
 ```
 
 **Arguments**:
 
-* `DEVICE_ID...`: [required]
+* `DEVICE_IDS...`: [required]
 * `SERVER_ID`: [required]
 
 **Options**:

--- a/pyaxm/cli.py
+++ b/pyaxm/cli.py
@@ -4,6 +4,7 @@ import typer
 from typing_extensions import Annotated
 from typing import List
 from pyaxm.client import Client
+from pyaxm.utils import download_activity_csv
 
 app = typer.Typer()
 
@@ -80,6 +81,10 @@ def assign_device(device_id: Annotated[List[str], typer.Argument()], server_id: 
     df = pd.DataFrame([activity_data])
     df.to_csv(sys.stdout, index=False)
 
+    file_path = download_activity_csv(activity)
+    if file_path:
+        typer.echo(f"Report downloaded successfully to: {file_path}")
+
 @app.command()
 def unassign_device(device_id: Annotated[List[str], typer.Argument()], server_id: Annotated[str, typer.Argument()]):
     """Unassign one or more devices from an MDM server."""
@@ -89,6 +94,10 @@ def unassign_device(device_id: Annotated[List[str], typer.Argument()], server_id
     activity_data.update(activity.attributes.model_dump())
     df = pd.DataFrame([activity_data])
     df.to_csv(sys.stdout, index=False)
+    
+    file_path = download_activity_csv(activity)
+    if file_path:
+        typer.echo(f"Report downloaded successfully to: {file_path}")
 
 if __name__ == "__main__":
     app()

--- a/pyaxm/cli.py
+++ b/pyaxm/cli.py
@@ -72,10 +72,10 @@ def mdm_server_assigned(device_id: Annotated[str, typer.Argument()]):
     df.to_csv(sys.stdout, index=False)
 
 @app.command()
-def assign_device(device_id: Annotated[List[str], typer.Argument()], server_id: Annotated[str, typer.Argument()]):
+def assign_device(device_ids: Annotated[List[str], typer.Argument()], server_id: Annotated[str, typer.Argument()]):
     """Assign one or more devices to an MDM server."""
     client = Client()
-    activity = client.assign_unassign_device_to_mdm_server(device_id, server_id, 'ASSIGN_DEVICES')
+    activity = client.assign_unassign_device_to_mdm_server(device_ids, server_id, 'ASSIGN_DEVICES')
     activity_data = {'id': activity.id}
     activity_data.update(activity.attributes.model_dump())
     df = pd.DataFrame([activity_data])
@@ -86,10 +86,10 @@ def assign_device(device_id: Annotated[List[str], typer.Argument()], server_id: 
         typer.echo(f"Report downloaded successfully to: {file_path}")
 
 @app.command()
-def unassign_device(device_id: Annotated[List[str], typer.Argument()], server_id: Annotated[str, typer.Argument()]):
+def unassign_device(device_ids: Annotated[List[str], typer.Argument()], server_id: Annotated[str, typer.Argument()]):
     """Unassign one or more devices from an MDM server."""
     client = Client()
-    activity = client.assign_unassign_device_to_mdm_server(device_id, server_id, 'UNASSIGN_DEVICES')
+    activity = client.assign_unassign_device_to_mdm_server(device_ids, server_id, 'UNASSIGN_DEVICES')
     activity_data = {'id': activity.id}
     activity_data.update(activity.attributes.model_dump())
     df = pd.DataFrame([activity_data])

--- a/pyaxm/client.py
+++ b/pyaxm/client.py
@@ -157,10 +157,12 @@ class Client:
         )
 
         # use the ID to check the status until it is complete
+        # Waits before the first check to prevent rate limitting
+        time.sleep(10)
         activity_response = self.abm.get_device_activity(unassign_response.data.id, self.access_token.value)
         retry = 0
-        while 'COMPLETED' not in activity_response.data.attributes.status and retry < 5:
-            time.sleep(2 ** retry)
+        while activity_response.data.attributes.status == 'IN_PROGRESS' and retry < 5:
+            time.sleep(10 * retry)
             retry += 1
             activity_response = self.abm.get_device_activity(unassign_response.data.id, self.access_token.value)
 

--- a/pyaxm/utils.py
+++ b/pyaxm/utils.py
@@ -1,0 +1,39 @@
+import os
+import re
+import requests
+from typing import Optional
+from urllib.parse import urlparse, parse_qs
+from pyaxm.models import OrgDeviceActivity
+
+
+def download_activity_csv(activity: OrgDeviceActivity, save_path: str = None) -> Optional[str]:
+    """
+    Download CSV file from activity if download URL is available.
+    
+    :param activity: OrgDeviceActivity object with attributes.downloadUrl property
+    :param save_path: Optional path to save file (defaults to current directory)
+    :return: Path to saved file or None if no download URL
+    """
+    if not save_path:
+        save_path = os.getcwd()
+
+    if not (activity.attributes and activity.attributes.downloadUrl):
+        return None
+
+    url = activity.attributes.downloadUrl
+    parsed_url = urlparse(url)
+    query_params = parse_qs(parsed_url.query)
+    
+    disposition = query_params['response-content-disposition'][0]
+    match = re.search(r'filename="([^"]+)"', disposition)
+    filename = match.group(1)
+    
+    file_path = os.path.join(save_path, filename)
+    
+    response = requests.get(url)
+    response.raise_for_status()
+    
+    with open(file_path, 'wb') as f:
+        f.write(response.content)
+    
+    return file_path


### PR DESCRIPTION
adds a download util to download the resulting file from OrgDeviceActivity object

adds an initial wait time of 10 seconds for the result of assign/unassign devices to prevent rate limitting

updates parameters from device_id to device_ids when refering to a list of devices

updates unassignment/assignment command to include downloading the CSV with the result

updates cli.md and readme.md with changes