### PR TITLE
fix: normalize Apple .p8 EC key PEM header/footer on load

### DIFF
--- a/pyaxm/auth.py
+++ b/pyaxm/auth.py
@@ -5,6 +5,8 @@ import uuid
 from dataclasses import dataclass
 
 import jwt
+from cryptography.hazmat.primitives import serialization as crypto_serialization
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
 
 @dataclass
@@ -35,6 +37,27 @@ class TokenManager:
         self.token_path = token_path
         self.access_token = self._get_or_refresh_token()
 
+    def _load_ec_key(self) -> bytes:
+        """Load and normalize an Apple .p8 EC private key.
+
+        Apple provides EC private keys in PKCS#8 PEM format
+        (``-----BEGIN PRIVATE KEY-----``).  Some PyJWT or
+        ``cryptography`` releases can be sensitive to the exact PEM
+        header / footer wording or encoding.  To avoid any such issues,
+        this helper loads the key with ``cryptography`` (which
+        transparently handles both PKCS#8 and SEC1 / EC PEM formats)
+        and re-serialises it back to a consistent PKCS#8 PEM byte
+        string.
+        """
+        with open(self.key_path, "rb") as f:
+            key_data = f.read()
+        private_key = load_pem_private_key(key_data, password=None)
+        return private_key.private_bytes(
+            encoding=crypto_serialization.Encoding.PEM,
+            format=crypto_serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=crypto_serialization.NoEncryption(),
+        )
+
     def _generate_assertion(self) -> str:
         issued_at = int(dt.datetime.now(dt.timezone.utc).timestamp())
         expires_at = issued_at + 60
@@ -50,8 +73,7 @@ class TokenManager:
             "jti": str(uuid.uuid4()),
             "iss": self.axm_client_id,
         }
-        with open(self.key_path, "rb") as f:
-            key = f.read()
+        key = self._load_ec_key()
         return jwt.encode(payload, key, algorithm="ES256", headers=headers)
 
     def _get_or_refresh_token(self) -> AccessToken:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "2026.5.18"
 description = "Query Apple Business Manager using Python"
 requires-python = ">=3.10"
 dependencies = [
+  "cryptography",
   "pydantic",
   "requests",
   "pyjwt",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cryptography
 pydantic
 requests
 pyjwt


### PR DESCRIPTION
Apple provides EC private keys in PKCS#8 PEM format (-----BEGIN PRIVATE KEY-----). The raw key bytes passed directly to jwt.encode() can fail in some PyJWT or cryptography releases due to sensitivity to the exact PEM header/footer wording or encoding.

Add a _load_ec_key() helper that loads the key through cryptography's load_pem_private_key() — which handles both PKCS#8 and SEC1/EC PEM formats transparently — and re-serialises it to a consistent PKCS#8 PEM byte string before handing it to PyJWT.